### PR TITLE
[TASK] Add extension configuration to hide all inline content elements

### DIFF
--- a/Classes/InlineContentFetcher.php
+++ b/Classes/InlineContentFetcher.php
@@ -6,6 +6,7 @@ namespace Supseven\InlinePageModule;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Backend\View\BackendLayout\ContentFetcher;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -19,6 +20,8 @@ use TYPO3\CMS\Core\Versioning\VersionState;
 class InlineContentFetcher extends ContentFetcher
 {
     private ?array $usedIds = null;
+
+    private array $impossibleCeId = [-99];
 
     protected function getResult($result): array
     {
@@ -83,8 +86,18 @@ class InlineContentFetcher extends ContentFetcher
                     // If the parent has no elements yet, we restrict to an "impossible ID"
                     // to make sure no elements are shown
                     if (!$result) {
-                        $result = [-99];
+                        $result = $this->impossibleCeId;
                     }
+                }
+            } else {
+                // If the content elements are not restricted by a specific parent element (above condition)
+                // and the extension configuration is set to list no content elements at all,
+                // we restrict to an "impossible ID", too
+                $listAllContentElements = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ExtensionConfiguration::class)
+                                                                                ->get('inline_page_module', 'listAllContentElements');
+
+                if ($listAllContentElements !== '1') {
+                    $result = $this->impossibleCeId;
                 }
             }
         }

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Inline Page Module for TYPO3
 
-This is a TYPO3 extension that provides a page-module view for inline 
+This is a TYPO3 extension that provides a page-module view for inline
 tt_content records of non-page records, like news.
 
 ## Installation
@@ -17,13 +17,13 @@ Requires TYPO3 v10.4-10.5 in composer mode.
 
 ### Default
 
-> **Important**: EXT:inline_page_module does not come with defaults, like for 
-> news. All fields that should have a page view must be defined by an 
+> **Important**: EXT:inline_page_module does not come with defaults, like for
+> news. All fields that should have a page view must be defined by an
 > integrator.
 
-To add the function to a table, use the method 
-`\Supseven\InlinePageModule\PageModuleSwitcher::register` in a 
-`TCA/Overrides/table.php` file to generate the needed TCA settings. The 
+To add the function to a table, use the method
+`\Supseven\InlinePageModule\PageModuleSwitcher::register` in a
+`TCA/Overrides/table.php` file to generate the needed TCA settings. The
 function needs the name of the table as first parameter.
 
 ```php
@@ -33,9 +33,9 @@ function needs the name of the table as first parameter.
 
 ### With a backend layout
 
-The second parameter can a be the name of a backend layout. The 
-page module will then use this backend layout. This is useful if the backend 
-layout should have a different column name or if the `colPos` value of the 
+The second parameter can a be the name of a backend layout. The
+page module will then use this backend layout. This is useful if the backend
+layout should have a different column name or if the `colPos` value of the
 tt_content records differs from the inherited layout.
 
 eg. with a PageTS like this
@@ -64,19 +64,19 @@ This backend layout can be used with
 );
 ```
 
-All configurations for backend layouts remain unchanged, which includes 
-[`EXT:content_defender`](https://github.com/IchHabRecht/content_defender) 
+All configurations for backend layouts remain unchanged, which includes
+[`EXT:content_defender`](https://github.com/IchHabRecht/content_defender)
 restrictions.
 
-> **Important**: Having referenced records from multiple fields in several 
-> "colPos" in the same page layout view is currently not supported. Each field 
+> **Important**: Having referenced records from multiple fields in several
+> "colPos" in the same page layout view is currently not supported. Each field
 > has its own view.
 
 ### Restricting fields
 
-If a table has several fields with inline relations to tt_content records, 
-the page module switch is added to all of them. To restrict this to only one 
-or several fields, add the names of those fields to the parameter `$fields` 
+If a table has several fields with inline relations to tt_content records,
+the page module switch is added to all of them. To restrict this to only one
+or several fields, add the names of those fields to the parameter `$fields`
 of the method:
 
 ```php
@@ -87,43 +87,51 @@ of the method:
 );
 ```
 
+### Extension Configuration
+
+This extension provides a configuration `List all available content elements
+in page module`, which is disabled by default. A huge amount of content
+elements (e.g. provided from news records) can lead to a timeout, if the
+folder containing these inline content elements is accessed in the page
+module. This setting prevents from loading all content elements.
+
 ## Usage
 
-After following the example above, news records will have a "Edit in page 
+After following the example above, news records will have a "Edit in page
 view" button (red arrow):
 
 ![News content elements in form](./Documentation/Images/news-inline-records.jpg)
 
-Clicking this button will open the page module with the referenced 
+Clicking this button will open the page module with the referenced
 tt_content records:
 
 ![News content in page module](./Documentation/Images/news-page-module.jpg)
 
-In this view, all the common editing options, like drag-and-drop sorting or 
+In this view, all the common editing options, like drag-and-drop sorting or
 the "new" and "delete" buttons work like in the page module.
 
 The "Go back..." button is a link to the form of the parent record.
 
-In this view, the page-module navigation point on the left of the TYPO3 
+In this view, the page-module navigation point on the left of the TYPO3
 backend is not activated. Also, the page on which the parent record is, is
-(still) the selected. 
+(still) the selected.
 
 ## Legal
 
 ### License
 
-This package is provided under the GPL v3 license. See the file 
+This package is provided under the GPL v3 license. See the file
 [LICENSE](./LICENSE) or <https://www.gnu.org/licenses/gpl-3.0> for details.
 
 ### Notices
 
-TYPO3 is provided under the GPL license, v2 or later. See 
+TYPO3 is provided under the GPL license, v2 or later. See
 <https://typo3.org/project/licenses> for details.
 
-The "News" packaged mentioned in this document refers to 
-[extension news](https://github.com/georgringer/news/) provided under the 
+The "News" packaged mentioned in this document refers to
+[extension news](https://github.com/georgringer/news/) provided under the
 GPL v2 or later
 
-The extension icon is part of the the 
-[ionicons icon pack](https://ionic.io/ionicons) which is provided under the 
+The extension icon is part of the the
+[ionicons icon pack](https://ionic.io/ionicons) which is provided under the
 MIT license.

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" target-language="de" original="" datatype="plaintext" date="2023-09-22T13:05:18+02:00">
-		<body>
-			<trans-unit id="btn.openInPageModule" resname="btn.openInPageModule">
-				<source>Edit in page view</source>
-				<target>In Seitenansicht bearbeiten</target>
-			</trans-unit>
-			<trans-unit id="btn.back" resname="btn.back">
-				<source>Go back to %s  »%s«</source>
-				<target>Zurück zu %s  »%s«</target>
-			</trans-unit>
-		</body>
-	</file>
+    <file source-language="en" target-language="de" original="" datatype="plaintext" date="2024-02-19T09:19:21+01:00">
+        <body>
+            <trans-unit id="btn.back" resname="btn.back">
+                <source>Go back to %s  »%s«</source>
+                <target>Zurück zu %s  »%s«</target>
+            </trans-unit>
+            <trans-unit id="btn.openInPageModule" resname="btn.openInPageModule">
+                <source>Edit in page view</source>
+                <target>In Seitenansicht bearbeiten</target>
+            </trans-unit>
+            <trans-unit id="ext_conf_template.list_all_elements" resname="ext_conf_template.list_all_elements">
+                <source>List all available content elements in page module</source>
+                <target>Im Seiten-Modul alle Inhaltselemente anzeigen</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file source-language="en" original="" datatype="plaintext" date="2023-09-22T13:05:18+02:00">
-		<body>
-			<trans-unit id="btn.openInPageModule" resname="btn.openInPageModule">
-				<source>Edit in page view</source>
-			</trans-unit>
-			<trans-unit id="btn.back" resname="btn.back">
-				<source>Go back to %s  »%s«</source>
-			</trans-unit>
-		</body>
-	</file>
+    <file source-language="en" original="" datatype="plaintext" date="2024-02-19T09:19:21+01:00">
+        <body>
+            <trans-unit id="btn.back" resname="btn.back">
+                <source>Go back to %s  »%s«</source>
+            </trans-unit>
+            <trans-unit id="btn.openInPageModule" resname="btn.openInPageModule">
+                <source>Edit in page view</source>
+            </trans-unit>
+            <trans-unit id="ext_conf_template.list_all_elements" resname="ext_conf_template.list_all_elements">
+                <source>List all available content elements in page module</source>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=basic; type=boolean; label=LLL:EXT:inline_page_module/Resources/Private/Language/locallang_be.xlf:ext_conf_template.list_all_elements
+listAllContentElements = 0


### PR DESCRIPTION
If a folder is opened in the page module and this extension does not constrain the listed inline content elements by a specific content element id (parent id), too many content elements might have to be listed, which slows down the backend view or even runs the application into a timeout.

This commit adds an extension configuration parameter to prevent the backend view from showing all inline content elements, even if no parent content element id is provided.